### PR TITLE
Map Rotation API

### DIFF
--- a/app.py
+++ b/app.py
@@ -498,7 +498,9 @@ def json_mapquery():
     deltas = list(map(lambda s: s.find_next_play(search_map_id), api.servers.values()))
     # remove all None from servers which do not have map
     deltas = [i for i in deltas if i[0]]
-    return json.dumps([search_map_id, deltas])
+    # return json.dumps([search_map_id, deltas]) # return [mapid, timedelta]
+    # return time delta to queried map
+    return [deltas]
 
 
 def build_fin_json():

--- a/app.py
+++ b/app.py
@@ -490,13 +490,13 @@ def json_mapquery():
     try:
         search_map_id = int(req_map)
     except ValueError:
-        return "error"
+        return "- never, check your inputs!"
     except TypeError:
-        return "error"
+        return "- never, check your inputs!"
     # check if input is in current map pool
     if search_map_id < MAPIDS[0] or search_map_id > MAPIDS[1]:
         # not in current map pool
-        return "error"
+        return "- never, check your inputs!"
 
     api.get_mapinfo()
     # input seems ok, try to find next time map is played

--- a/app.py
+++ b/app.py
@@ -478,6 +478,29 @@ def json_fin_provider():
         return build_fin_json()
 
 
+@app.route('/mapquery.json', methods=['GET'])
+def json_mapquery():
+    req_map = flask.request.args.get("mapid")
+    # check if input is integer
+    try:
+        search_map_id = int(req_map)
+    except ValueError:
+        return "error"
+    except TypeError:
+        return "error"
+    # check if input is in current map pool
+    if search_map_id < MAPIDS[0] or search_map_id > MAPIDS[1]:
+        # not in current map pool
+        return "error"
+
+    api.get_mapinfo()
+    # input seems ok, try to find next time map is played
+    deltas = list(map(lambda s: s.find_next_play(search_map_id), api.servers.values()))
+    # remove all None from servers which do not have map
+    deltas = [i for i in deltas if i[0]]
+    return json.dumps([search_map_id, deltas])
+
+
 def build_fin_json():
     """
     Provides the finished maps for a given TM login as Python dict.

--- a/config.yaml
+++ b/config.yaml
@@ -33,3 +33,7 @@ logtype: STDOUT # STDOUT, FILE
 logfile: flask.log # might require absolute path
 loglevel: DEBUG # DEBUG, INFO, WARNING, ERROR, CRITICAL
 logger_name: KKmaptimes
+
+# TESTING MODE
+testing_mode: 1
+testing_compend: 30.01.2050 22:00

--- a/config.yaml
+++ b/config.yaml
@@ -35,5 +35,5 @@ loglevel: DEBUG # DEBUG, INFO, WARNING, ERROR, CRITICAL
 logger_name: KKmaptimes
 
 # TESTING MODE
-testing_mode: 1
+testing_mode: 0
 testing_compend: 30.01.2050 22:00

--- a/datastructures/playlist.py
+++ b/datastructures/playlist.py
@@ -45,6 +45,7 @@ class PlaylistHandler:
 
     def _minutes_to_hourmin_str(self, minutes):
         minutes = int(minutes)
+        # return Tuple[str, str] # (hours, minutes)
         return f"{int(minutes / 60):0>2d}", f"{minutes % 60:0>2d}"
 
     def get_playlist_from_now(self):

--- a/kacky_api_handler.py
+++ b/kacky_api_handler.py
@@ -38,17 +38,19 @@ class KackyAPIHandler:
 
         self.logger.info("Updating self.servers.")
         try:
-            krdata = requests.get("https://kk.kackiestkacky.com/api/", params={"password": self.api_pwd}).json()
+            if self.config["testing_mode"]:
+                self.logger.error("Using TEST_API_RESPONSE")
+                krdata = TEST_API_RESPONSE
+            else:
+                krdata = requests.get("https://kk.kackiestkacky.com/api/", params={"password": self.api_pwd}).json()
         except ConnectionError:
             self.logger.error("Could not connect to KK API!")
             flask.render_template('error.html',
                                   error="Could not contact KK server. RIP!")
             return
         except json.decoder.JSONDecodeError:
-            # self.logger.error("Using TEST_API_RESPONSE")
             # flask.render_template('error.html',
             #                      error="KK API returned strange data. RIP!")
-            # krdata = TEST_API_RESPONSE
             self.logger.error("Could not connect to KK API!")
             flask.render_template('error.html',
                                   error="Could not contact KK server. RIP!")


### PR DESCRIPTION
- Adds a testing mode
- Adds an API endpoint which allows to query when a map is played next. Takes map# as input, returns string "hours:minutes" that remain until played